### PR TITLE
Add support to access kafka in gcloud kubernete cluster

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ setup(
     py_modules=['kafkatunnel','Instance'],
     install_requires=[
         'Click',
-        'boto3'
+        'boto3',
+        'kubernetes',
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
The CL is to 
1. Add GKEInstance to retrieve kafka broker's IP in gcloud kubernete cluster with kubernete API
2. Do gcloud compute ssh when there is zone argument