### PR TITLE
Adding ability to authenticate jump host using certificate and some other helpful functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ kafkatunnel aws ec2-user@awsjumphost
 * manual passing your remote zookeeper/kafka and optionally schema registry IPs
 
 ```bash
-$ kafkatunnel manual 10.11.85.128,10.11.82.30,10.11.83.9 10.11.80.7,10.11.80.123,10.11.81.13 10.11.82.10,10.11.82.11
+$ kafkatunnel manual ec2-user@awsjumphost 10.11.85.128,10.11.82.30,10.11.83.9 10.11.80.7,10.11.80.123,10.11.81.13 10.11.82.10,10.11.82.11
 ```
 afterwards you have to provide your root password in order to create the interfaces
 


### PR DESCRIPTION
This PR is not intended to be merged, I just wanted to show the changes I've made for our use case and get some feedback on whether some of these changes would be welcome into the main project.

# Use Case
In my use case I'm spawning kafka-tunnel from a script (node, but that's not really important) to setup kafka access so I can perform data collection and exit. Ideally, this is an all in one script. So I don't run kafka-tunnel separately, then run my script, the script runs kafka-tunnel itself.

# non-graceful exit cleanup
The first changes I added was a command to delete interfaces (cleanmanual and cleanaws). This was because when I terminated my script (and it terminated kafka-tunnel) the interfaces were left registered. So I added these two commands as mirrors to `aws` and `manual` so you can remove the interfaces if they don't get cleaned up.

But additionally, in order to eliminate the need of having to clean them up, I added signal handlers for SIGINT and SIGQUIT to clean them up when those signals are received. But I suspect there are a few other edge cases where kafka-tunnel could exit without cleaning up. 
**Would you be interested in the signal handler catching & cleanup PR?**
**Would you be interested in manualclean and awsclean command PR?**

# Jump Host Authentication via Certificate
We use public/private keys to ssh into our jump host. So I needed a way to provide the path to the private key to the SSH call. I added the options `-jc --jump_host_cert` to provide this path. 
**Would you be interested in a jump host cert PR?**

# SSH No commands option
Because we're running kafka-tunnel from a script, a tty-terminal is not available to ssh. I'm passing `-N` option to ssh to get around this. This eliminates the open terminal to the jump host. I wasn't sure what I wanted to do to make this configurable. The easy answer is add a new option ie `-nc --no_commands`, but I'm wondering if there is a better convention to support passing through 1 or more options to SSH, than exposing all the potentially ssh options a user might want to the kafka-tunnel command options. Is there a method to provide a repeatable option that gets passed through? Ie `-S "-i /path/to/key"` `-S "-N"`? 
**Would you be interested in a custom/extra SSH options PR?**
**Do you have recommendations on how to provide the custom options beside mirroring the options in the aws and manual commands?**

I'd be happy to make separate PR's for each feature you're interested in.

Thanks