### PR TITLE
Use -N in ssh tunnel to work with more restrictive setups

### DIFF
--- a/kafkatunnel.py
+++ b/kafkatunnel.py
@@ -77,7 +77,7 @@ def connect_ssh_tunnel(jump_host,instances):
     click.echo(' * connecting to jump host ' + jump_host)
     opts = []
     for i in instances:
-        opts += ['-L','{ip}:{port}:{ip}:{port}'.format(ip=i.ip,port=i.port)]
+        opts += ['-N', '-L','{ip}:{port}:{ip}:{port}'.format(ip=i.ip,port=i.port)]
     subprocess.call(['ssh'] + opts + [jump_host])
 
 if __name__ == '__main__':


### PR DESCRIPTION
We're running into a situation where we want to use a jump host that doesn't allow PTY or command execution and only allows port forwarding tunnels. This PR adds the `-N Do not execute a remote command.  This is useful for just forwarding ports.` option to the ssh command. I believe it's backwards compatible but it will change the output folks are used to seeing.